### PR TITLE
Big locking refactoing

### DIFF
--- a/src/file_depot.rs
+++ b/src/file_depot.rs
@@ -1,74 +1,69 @@
-use crate::{info, log};
+use crate::{info, log_message};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use std::sync::Mutex;
 use tower_lsp::lsp_types::{MessageType, Url};
 
-#[allow(clippy::struct_field_names)]
+#[derive(Default, Clone)]
+struct FileEntry {
+    text: Option<String>,
+    includes: Vec<Url>,
+    included_by: Vec<Url>,
+}
+
+#[derive(Clone)]
 struct Data {
-    url_to_text: HashMap<Url, String>,
-    url_includes: HashMap<Url, Arc<Mutex<Vec<Url>>>>,
-    url_included_by: HashMap<Url, Arc<Mutex<Vec<Url>>>>,
+    entries: HashMap<Url, FileEntry>,
 }
 
 impl Data {
     fn new() -> Data {
         Data {
-            url_to_text: HashMap::new(),
-            url_includes: HashMap::new(),
-            url_included_by: HashMap::new(),
+            entries: HashMap::new(),
         }
     }
 
-    fn insert(&mut self, uri: &Url, text: String) {
-        if self.url_to_text.contains_key(uri) {
-            return;
-        }
+    fn insert(&mut self, uri: &Url, text: &str) {
+        let e = self.entries.entry(uri.clone()).or_default();
 
-        self.url_to_text.insert(uri.clone(), text);
+        if e.text.is_none() {
+            e.text = Some(text.to_string());
+        }
     }
 
-    async fn add_include(&mut self, uri: &Url, include_uri: &Url) {
-        let e = self.url_includes.entry(uri.clone()).or_default();
-        {
-            let mut e = e.lock().await;
-            e.push(include_uri.clone());
-        }
+    fn add_include(&mut self, uri: &Url, include_uri: &Url) {
+        let e = self.entries.entry(uri.clone()).or_default();
+        e.includes.push(include_uri.clone());
 
-        let e = self.url_included_by.entry(include_uri.clone()).or_default();
-        {
-            let mut e = e.lock().await;
-            e.push(uri.clone());
-        }
+        let e = self.entries.entry(include_uri.clone()).or_default();
+        e.included_by.push(uri.clone());
     }
 
     //TODO: -> HashSet<Url> or Make sure no repetition
-    async fn get_component(&self, uri: &Url) -> Vec<Url> {
+    fn get_component(&self, uri: &Url) -> Vec<Url> {
         // Process includes
         let mut to_visit = vec![uri.clone()];
         let mut visited = HashSet::new();
         let mut res: Vec<Url> = Vec::new();
         while let Some(uri) = to_visit.pop() {
-            if let Some(e) = self.url_includes.get(&uri) {
-                let x = e.lock().await.clone();
-                for f in &x {
+            if let Some(e) = self.entries.get(&uri) {
+                for f in &e.includes {
                     if !visited.contains(f) {
                         to_visit.push(f.clone());
                         res.push(f.clone());
-                        visited.insert(f.clone());
+                        visited.insert(uri.clone());
                     }
                 }
             }
+
             visited.insert(uri);
         }
 
         // Process included by
         let mut to_visit = Vec::new();
-        //let mut visited = HashSet::new();
-        if let Some(e) = self.url_included_by.get(uri) {
-            let x = e.lock().await.clone();
-            for f in &x {
+        if let Some(e) = self.entries.get(uri) {
+            for f in &e.included_by {
                 if !visited.contains(f) {
                     to_visit.push(f.clone());
                     visited.insert(f.clone());
@@ -76,20 +71,10 @@ impl Data {
                 }
             }
         }
+
         while let Some(uri) = to_visit.pop() {
-            if let Some(e) = self.url_includes.get(&uri) {
-                let x = e.lock().await.clone();
-                for f in &x {
-                    if !visited.contains(f) {
-                        to_visit.push(f.clone());
-                        visited.insert(f.clone());
-                        res.push(f.clone());
-                    }
-                }
-            }
-            if let Some(e) = self.url_included_by.get(&uri) {
-                let x = e.lock().await.clone();
-                for f in &x {
+            if let Some(e) = self.entries.get(&uri) {
+                for f in e.includes.iter().chain(e.included_by.iter()) {
                     if !visited.contains(f) {
                         to_visit.push(f.clone());
                         visited.insert(f.clone());
@@ -102,15 +87,12 @@ impl Data {
         res
     }
 
-    async fn get_neighbours(&self, uri: &Url) -> Vec<Url> {
+    fn get_neighbours(&self, uri: &Url) -> Vec<Url> {
         let mut res = Vec::new();
 
-        if let Some(x) = self.url_includes.get(uri) {
-            res.extend_from_slice(&x.lock().await);
-        }
-
-        if let Some(x) = self.url_included_by.get(uri) {
-            res.extend_from_slice(&x.lock().await);
+        if let Some(x) = self.entries.get(uri) {
+            res.extend_from_slice(&x.includes);
+            res.extend_from_slice(&x.included_by);
         }
 
         res
@@ -118,17 +100,12 @@ impl Data {
 
     async fn dump(&self) {
         info!("===FILES===");
-        for uri in self.url_to_text.keys() {
+        for uri in self.entries.keys() {
             info!("{uri}");
         }
         info!("=INCLUDES=");
-        for (k, v) in &self.url_includes {
-            for f in v.lock().await.iter() {
-                info!("url: {k}: {f}");
-            }
-        }
-        for (k, v) in &self.url_included_by {
-            for f in v.lock().await.iter() {
+        for (k, v) in &self.entries {
+            for f in v.includes.iter().chain(v.included_by.iter()) {
                 info!("url: {k}: {f}");
             }
         }
@@ -136,16 +113,16 @@ impl Data {
     }
 
     fn exist(&self, uri: &Url) -> bool {
-        self.url_to_text.contains_key(uri)
+        self.entries.contains_key(uri)
     }
 
     fn get_text(&self, uri: &Url) -> Option<String> {
-        self.url_to_text.get(uri).cloned()
+        self.entries.get(uri).and_then(|x| x.text.clone())
     }
 
     #[cfg(test)]
     fn size(&self) -> usize {
-        self.url_to_text.keys().count()
+        self.entries.keys().count()
     }
 }
 
@@ -162,37 +139,48 @@ impl FileDepot {
     }
 
     pub async fn insert(&self, uri: &Url, text: String) {
-        let mut data = self.data.lock().await;
-        data.insert(uri, text);
+        info!("FileDepot::insert()");
+        let mut data = self.data.lock().unwrap();
+        data.insert(uri, &text);
     }
 
     pub async fn dump(&self) {
-        self.data.lock().await.dump().await;
+        info!("FileDepot::dump()");
+        {
+            let lock = self.data.lock().unwrap();
+            lock.clone()
+        }
+        .dump()
+        .await;
     }
 
     pub async fn get_text(&self, uri: &Url) -> Option<String> {
-        self.data.lock().await.get_text(uri)
+        info!("FileDepot::get_text()");
+        self.data.lock().unwrap().get_text(uri)
     }
 
     pub async fn exist(&self, uri: &Url) -> bool {
-        self.data.lock().await.exist(uri)
+        info!("FileDepot::exist()");
+        self.data.lock().unwrap().exist(uri)
     }
 
     pub async fn add_include(&self, uri: &Url, include_uri: &Url) {
-        self.data.lock().await.add_include(uri, include_uri).await;
-        //self.data.lock().await.add_include(include_uri, uri).await;
+        info!("FileDepot::add_include()");
+        self.data.lock().unwrap().add_include(uri, include_uri);
     }
 
     pub async fn get_neighbours(&self, uri: &Url) -> Vec<Url> {
-        self.data.lock().await.get_neighbours(uri).await
+        info!("FileDepot::get_neighbours()");
+        self.data.lock().unwrap().get_neighbours(uri)
     }
 
     pub async fn get_component(&self, uri: &Url) -> Vec<Url> {
-        self.data.lock().await.get_component(uri).await
+        info!("FileDepot::get_component()");
+        self.data.lock().unwrap().get_component(uri)
     }
 
     #[cfg(test)]
     pub async fn size(&self) -> usize {
-        self.data.lock().await.size()
+        self.data.lock().unwrap().size()
     }
 }


### PR DESCRIPTION
- Switch to std::Mutex instead of tokio ones as recomended by tokio docs.
- Refactor logger to get rid of unnecessary async.
- Cleanup internal data structures of FileDepot.