### PR TITLE
Add arm64 OSX build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,10 @@ jobs:
             os: macos-latest
             target: x86_64-apple-darwin
 
+          - build: macos
+            os: macos-latest
+            target: aarch64-apple-darwin
+
           - build: windows
             os: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,12 @@ jobs:
             dependencies:
             binary_name: dts-lsp
 
+          - build: macos
+            os: macos-latest
+            target: aarch64-apple-darwin
+            dependencies:
+            binary_name: dts-lsp
+
           - build: windows
             os: windows-latest
             target: x86_64-pc-windows-msvc


### PR DESCRIPTION
Hi
I want to make a device tree support extension for a [zed editor](https://github.com/zed-industries/zed) based on your language server.
As Zed introduced Linux support, I want to make it more suitable for embedded Linux development. Still, a considerable part of the community uses Zed on Apple silicone-based Macs, even though it may not be for a device tree extension. 
This small commit adds an aarch64 build and release to the CI.
An extension can fetch it from GitHub releases and use LSP.